### PR TITLE
Theme diff colors (compare)

### DIFF
--- a/definitions/danganronpa/ibuki/dark/ibuki.dark.master.definition.json
+++ b/definitions/danganronpa/ibuki/dark/ibuki.dark.master.definition.json
@@ -50,6 +50,7 @@
     "htmlTagColor": "#a28a92",
     "stringColor": "#f4fa8c",
     "keyColor": "#5ea7ff",
-    "keywordColor": "#8b8b8b"
+    "keywordColor": "#8b8b8b",
+    "diff.deleted": "#404040"
   }
 }

--- a/definitions/highSchoolDxD/rias/dark/rias.dark.master.definition.json
+++ b/definitions/highSchoolDxD/rias/dark/rias.dark.master.definition.json
@@ -51,6 +51,10 @@
     "htmlTagColor": "#a28a92",
     "stringColor": "#9EB7D6",
     "keyColor": "#eea367",
-    "keywordColor": "#C04750"
+    "keywordColor": "#C04750",
+    "diff.deleted": "#412a2b",
+    "diff.conflict": "#57171a",
+    "diff.inserted": "#1c2331",
+    "diff.modified": "#102d0e"
   }
 }

--- a/definitions/killLaKill/satsuki/satsuki.master.definition.json
+++ b/definitions/killLaKill/satsuki/satsuki.master.definition.json
@@ -51,6 +51,8 @@
     "stringColor": "#b8397e",
     "keyColor": "#cd862f",
     "keywordColor": "#275AB3",
-    "constantColor": "#4C94D6"
+    "constantColor": "#4C94D6",
+    "diff.modified": "#B1CCE2",
+    "diff.deleted": "#d1d0dc"
   }
 }

--- a/definitions/literature/natsuki/light/natsuki.light.master.definition.json
+++ b/definitions/literature/natsuki/light/natsuki.light.master.definition.json
@@ -51,6 +51,7 @@
     "stringColor": "#DC872E",
     "keyColor": "#7C75EF",
     "constantColor":"#4C94D6",
-    "keywordColor": "#C869A3"
+    "keywordColor": "#C869A3",
+    "diff.conflict": "#FFA9BF"
   }
 }

--- a/definitions/luckyStar/konata/light/konata.light.master.definition.json
+++ b/definitions/luckyStar/konata/light/konata.light.master.definition.json
@@ -64,6 +64,11 @@
     "terminal.ansiYellow": "#ffb760",
     "terminal.ansiBlue": "#DABDFB",
     "terminal.ansiMagenta": "#F79B9E",
-    "terminal.ansiCyan": "#75D7EC"
+    "terminal.ansiCyan": "#75D7EC",
+
+    "diff.deleted": "#789AC4",
+    "diff.conflict": "#c2828a",
+    "diff.inserted": "#59A1CD",
+    "diff.modified": "#63A2FF"
   }
 }

--- a/definitions/reZero/beatrice/beatrice.master.definition.json
+++ b/definitions/reZero/beatrice/beatrice.master.definition.json
@@ -55,6 +55,7 @@
     "stringColor": "#DC872E",
     "keyColor": "#7C75EF",
     "constantColor":"#4C94D6",
-    "keywordColor": "#C869A3"
+    "keywordColor": "#C869A3",
+    "diff.conflict": "#FFA9BF"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doki-master-theme",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "The Doki Theme",
   "main": "build/index.js",
   "repository": "https://github.com/doki-theme/doki-master-theme.git",

--- a/templates/dark.colors.template.json
+++ b/templates/dark.colors.template.json
@@ -6,6 +6,10 @@
     "comments": "#6272a4",
     "caretForeground": "#ffffff",
     "lineNumberColor": "#666879",
-    "foregroundColorEditor": "#F8F8F2"
+    "foregroundColorEditor": "#F8F8F2",
+    "diff.deleted": "#565656",
+    "diff.conflict": "#5d323f",
+    "diff.inserted": "#204b21",
+    "diff.modified": "#203952"
   }
 }

--- a/templates/light.colors.template.json
+++ b/templates/light.colors.template.json
@@ -11,6 +11,10 @@
     "caretForeground": "#ffffff",
     "lineNumberColor": "#aaaaaa",
     "foregroundColorEditor": "#4D4D4A",
-    "parameterColor": "&accentColor&"
+    "parameterColor": "&accentColor&",
+    "diff.deleted": "#EBEBEB",
+    "diff.conflict": "#FFB6AE",
+    "diff.inserted": "#D0FDC9",
+    "diff.modified": "#9fe7ff"
   }
 }


### PR DESCRIPTION
- Added the doki-theme jetbrains diff/merge colors to the master themes so that the github themes can use them.