### PR TITLE
Support Jetbrains 2020.3 Support

### DIFF
--- a/definitions/fate/ishtar/dark/ishtar.dark.master.definition.json
+++ b/definitions/fate/ishtar/dark/ishtar.dark.master.definition.json
@@ -51,7 +51,7 @@
     "classNameColor": "#7C7C82",
     "htmlTagColor": "#e53935",
     "stringColor": "#a18649",
-    "keyColor": "#0f68b4",
+    "keyColor": "#0f6ab7",
     "keywordColor": "#db974d",
     "diff.modified": "#0E2539",
     "diff.inserted": "#132D14",

--- a/definitions/fate/rin/dark/rin.dark.master.definition.json
+++ b/definitions/fate/rin/dark/rin.dark.master.definition.json
@@ -47,6 +47,7 @@
     "codeBlock": "#211D1E",
     "textEditorBackground": "#161415",
     "searchResultBackground": "#211D1E",
+    "unusedColor": "#3D3D42",
     "classNameColor": "#4593f5",
     "htmlTagColor": "#e0474b",
     "stringColor": "#69e0f5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doki-master-theme",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "The Doki Theme",
   "main": "build/index.js",
   "repository": "https://github.com/doki-theme/doki-master-theme.git",

--- a/templates/base.colors.template.json
+++ b/templates/base.colors.template.json
@@ -5,6 +5,7 @@
     "constantColor":"#86dbfd",
     "parameterColor":"#FFB86C",
     "commentColor": "#6272A4",
+    "errorColor": "#ff5555",
     "terminal.ansiRed": "#E356A7",
     "terminal.ansiGreen": "#42E66C",
     "terminal.ansiYellow": "#EFA554",


### PR DESCRIPTION
- Better Rin dark unused colors
- Lighter Ishtar dark key color
- Bump version to 6.1.2
