### PR TITLE
VS Code v8.0.0 Support

### DIFF
--- a/definitions/luckyStar/konata/dark/konata.dark.master.definition.json
+++ b/definitions/luckyStar/konata/dark/konata.dark.master.definition.json
@@ -53,6 +53,7 @@
     "accentColorMoreTransparent": "#4bcf4c2A",
     "accentColor": "#4bcf4c",
     "accentColorBrighter": "#60ff62",
+    "accentContrastColor": "#355082",
     "stopColor": "#98ff3d",
     "testScopeColor": "#2d5572",
     "popupMask": "#648adc20",

--- a/definitions/reZero/emilia/dark/emilia.dark.master.definition.json
+++ b/definitions/reZero/emilia/dark/emilia.dark.master.definition.json
@@ -21,7 +21,7 @@
     "caretRow": "#543466",
     "caretForeground": "#ffffff",
     "lineNumberColor": "#666879",
-    "commentColor": "#8986A3",
+    "comments": "#8986A3",
     "infoForeground": "#a775ab",
     "completionWindowBackground": "#37323f",
     "baseIconColor": "#816b96",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doki-master-theme",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "The Doki Theme",
   "main": "build/index.js",
   "repository": "https://github.com/doki-theme/doki-master-theme.git",

--- a/templates/base.colors.template.json
+++ b/templates/base.colors.template.json
@@ -4,7 +4,7 @@
   "colors": {
     "constantColor":"#86dbfd",
     "parameterColor":"#FFB86C",
-    "commentColor": "#6272A4",
+    "comments": "#6272A4",
     "errorColor": "#ff5555",
     "terminal.ansiRed": "#E356A7",
     "terminal.ansiGreen": "#42E66C",


### PR DESCRIPTION
Added items to support the color themes for [this Doki Theme VSCode](https://github.com/doki-theme/doki-theme-vscode/releases/tag/v8.0.0) release.
